### PR TITLE
GM-1894- Allow Tomcat server.xml to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ docker run -d \
     thinkwhere/geserver
 ```
 
+It is also possible to pass in custom values to Tomcat which are controlled in server.xml, for example `MaxHttpHeaderSize`. A full list of these parameters can be found in `build/tomcat/update_tomcat_settings.sh`
+
+Environemnt variables can be passed in to the `docker run` command, as well as a request to run `update_tomcat_settings.sh` which will pass these values into the Tomcat `server.xml`. 
+
+For example - 
+
+```shell
+docker run -e "HTTP_MAX_HEADER_SIZE=524288" -t thinkwhere/geoserver:2.18.3 /bin/sh -c conf/update_tomcat_settings.sh
+```
+
+
 This repository contains a ``run.sh`` script for your convenience.
 
 ### Using docker-compose

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -93,13 +93,11 @@ RUN if ls /tmp/resources/fonts/*.ttf > /dev/null 2>&1; then \
       cp -rf /tmp/resources/fonts/*.ttf /usr/share/fonts/truetype/; \
 	fi;
 
-# Pass in any custom parameters into the Tomcat server.xml config file
-RUN . /tmp/resources/tomcat/update_tomcat_settings.sh
+# Copy across script and XML stylesheet which will allow the Tomcat server.xml to be parameterised
+RUN cp /tmp/resources/tomcat/* $CATALINA_HOME/conf/
 
 # Delete resources after installation
 RUN rm -rf /tmp/resources
 
-
-#ENTRYPOINT "/opt/geoserver/bin/startup.sh"
-#CMD "/opt/geoserver/bin/startup.sh"
+# CMD "/opt/geoserver/bin/startup.sh"
 EXPOSE 8080

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
 FROM tomcat:9.0-jre11-slim
 MAINTAINER thinkWhere<info@thinkwhere.com>
-#Credit: Tim Sutton<tim@linfiniti.com>
+# Credit: Tim Sutton<tim@linfiniti.com>
 # kartoza/docker-geoserver
 
 RUN apt-get -y update; apt-get -y install libapr1-dev \
@@ -88,10 +88,13 @@ RUN if ls /tmp/resources/plugins/*.zip > /dev/null 2>&1; then \
       done; \
     fi;
 
-# install Font files in resources/fonts if they exist
+# Install Font files in resources/fonts if they exist
 RUN if ls /tmp/resources/fonts/*.ttf > /dev/null 2>&1; then \
       cp -rf /tmp/resources/fonts/*.ttf /usr/share/fonts/truetype/; \
 	fi;
+
+# Pass in any custom parameters into the Tomcat server.xml config file
+RUN . /tmp/resources/tomcat/update_tomcat_settings.sh
 
 # Delete resources after installation
 RUN rm -rf /tmp/resources

--- a/build/resources/tomcat/tomcat_server_stylesheet.xsl
+++ b/build/resources/tomcat/tomcat_server_stylesheet.xsl
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  
+    <xsl:output method="xml" indent="yes"/>
+    
+    <xsl:param name="http.port"/>
+    <xsl:param name="http.proxyName"/>
+    <xsl:param name="http.proxyPort"/>
+    <xsl:param name="http.redirectPort"/>
+    <xsl:param name="http.connectionTimeout"/>
+    <xsl:param name="http.compression"/>
+    <xsl:param name="http.maxHttpHeaderSize"/>
+    <xsl:param name="https.port"/>
+    <xsl:param name="https.maxThreads"/>
+    <xsl:param name="https.clientAuth"/>
+    <xsl:param name="https.proxyName"/>
+    <xsl:param name="https.proxyPort"/>
+    <xsl:param name="https.keystoreFile"/>
+    <xsl:param name="https.keystorePass"/>
+    <xsl:param name="https.keyAlias"/>
+    <xsl:param name="https.keyPass"/>
+    <xsl:param name="https.compression"/>
+    <xsl:param name="https.maxHttpHeaderSize"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- redirect HTTP to HTTPS-->
+    <!-- @redirectPort requires security-constraint in web.xml: https://tomcat.apache.org/tomcat-8.0-doc/config/http.html -->
+    <xsl:template match="Connector[@protocol = 'HTTP/1.1']">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+
+            <xsl:if test="$http.port">
+                <xsl:attribute name="port">
+                    <xsl:value-of select="$http.port"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$http.proxyName">
+                <xsl:attribute name="proxyName">
+                    <xsl:value-of select="$http.proxyName"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$http.proxyPort">
+                <xsl:attribute name="proxyPort">
+                    <xsl:value-of select="$http.proxyPort"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$http.redirectPort">
+                <xsl:attribute name="redirectPort">
+                    <xsl:value-of select="$http.redirectPort"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$http.connectionTimeout">
+                <xsl:attribute name="connectionTimeout">
+                    <xsl:value-of select="$http.connectionTimeout"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$http.compression">
+                <xsl:attribute name="compression">
+                    <xsl:value-of select="$http.compression"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$http.maxHttpHeaderSize">
+                <xsl:attribute name="maxHttpHeaderSize">
+                    <xsl:value-of select="$http.maxHttpHeaderSize"/>
+                </xsl:attribute>
+            </xsl:if>
+
+            <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- enable HTTPS if it's not already enabled -->
+    <xsl:template match="Service[not(Connector/@protocol = 'org.apache.coyote.http11.Http11NioProtocol')]/*[last()]">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+        
+        <Connector port="{$https.port}" protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   maxThreads="{$https.maxThreads}" SSLEnabled="true" scheme="https" secure="true"
+                   keystoreFile="{$https.keystoreFile}" keystorePass="{$https.keystorePass}"
+                   keyAlias="{$https.keyAlias}" keyPass="{$https.keyPass}"
+                   sslProtocol="TLS">
+            <xsl:if test="$https.proxyName">
+                <xsl:attribute name="proxyName">
+                    <xsl:value-of select="$https.proxyName"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$https.proxyPort">
+                <xsl:attribute name="proxyPort">
+                    <xsl:value-of select="$https.proxyPort"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$https.clientAuth">
+                <xsl:attribute name="clientAuth">
+                    <xsl:value-of select="$https.clientAuth"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$https.compression">
+                <xsl:attribute name="compression">
+                    <xsl:value-of select="$https.compression"/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="$https.maxHttpHeaderSize">
+                <xsl:attribute name="maxHttpHeaderSize">
+                    <xsl:value-of select="$https.maxHttpHeaderSize"/>
+                </xsl:attribute>
+            </xsl:if>
+        </Connector>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/build/resources/tomcat/update_tomcat_settings.sh
+++ b/build/resources/tomcat/update_tomcat_settings.sh
@@ -1,8 +1,10 @@
+#!/bin/bash
+
 # Update Tomcat server settings
 # Inspired by https://github.com/kartoza/docker-geoserver
 
-# Copy across stylesheet which will be used to parse the Tomcat server.xml config file
-cp /tmp/resources/tomcat/tomcat_server_stylesheet.xsl ${CATALINA_HOME}/conf/tomcat_server_stylesheet.xsl
+# Backup Tomcat server config before making any changes
+cp ${CATALINA_HOME}/conf/server.xml ${CATALINA_HOME}/conf/server_backup.xml
 
 # Setup any variables which have been passed into the build
 if [ -n "$HTTP_PORT" ]; then
@@ -101,3 +103,6 @@ transform="xsltproc \
   ${CATALINA_HOME}/conf/server.xml"
 
 eval "$transform"
+
+# un server
+. $CATALINA_HOME/bin/catalina.sh run

--- a/build/resources/tomcat/update_tomcat_settings.sh
+++ b/build/resources/tomcat/update_tomcat_settings.sh
@@ -104,5 +104,5 @@ transform="xsltproc \
 
 eval "$transform"
 
-# un server
+# Run server
 . $CATALINA_HOME/bin/catalina.sh run

--- a/build/resources/tomcat/update_tomcat_settings.sh
+++ b/build/resources/tomcat/update_tomcat_settings.sh
@@ -1,0 +1,103 @@
+# Update Tomcat server settings
+# Inspired by https://github.com/kartoza/docker-geoserver
+
+# Copy across stylesheet which will be used to parse the Tomcat server.xml config file
+cp /tmp/resources/tomcat/tomcat_server_stylesheet.xsl ${CATALINA_HOME}/conf/tomcat_server_stylesheet.xsl
+
+# Setup any variables which have been passed into the build
+if [ -n "$HTTP_PORT" ]; then
+  HTTP_PORT_PARAM="--stringparam http.port $HTTP_PORT "
+fi
+
+if [ -n "$HTTP_PROXY_NAME" ]; then
+  HTTP_PROXY_NAME_PARAM="--stringparam http.proxyName $HTTP_PROXY_NAME "
+fi
+
+if [ -n "$HTTP_PROXY_PORT" ]; then
+  HTTP_PROXY_PORT_PARAM="--stringparam http.proxyPort $HTTP_PROXY_PORT "
+fi
+
+if [ -n "$HTTP_REDIRECT_PORT" ]; then
+  HTTP_REDIRECT_PORT_PARAM="--stringparam http.redirectPort $HTTP_REDIRECT_PORT "
+fi
+
+if [ -n "$HTTP_CONNECTION_TIMEOUT" ]; then
+  HTTP_CONNECTION_TIMEOUT_PARAM="--stringparam http.connectionTimeout $HTTP_CONNECTION_TIMEOUT "
+fi
+
+if [ -n "$HTTP_COMPRESSION" ]; then
+  HTTP_COMPRESSION_PARAM="--stringparam http.compression $HTTP_COMPRESSION "
+fi
+
+if [ -n "$HTTP_MAX_HEADER_SIZE" ]; then
+  HTTP_MAX_HEADER_SIZE_PARAM="--stringparam http.maxHttpHeaderSize $HTTP_MAX_HEADER_SIZE "
+fi
+
+if [ -n "$HTTPS_PORT" ]; then
+  HTTPS_PORT_PARAM="--stringparam https.port $HTTPS_PORT "
+fi
+
+if [ -n "$HTTPS_MAX_THREADS" ]; then
+  HTTPS_MAX_THREADS_PARAM="--stringparam https.maxThreads $HTTPS_MAX_THREADS "
+fi
+
+if [ -n "$HTTPS_CLIENT_AUTH" ]; then
+  HTTPS_CLIENT_AUTH_PARAM="--stringparam https.clientAuth $HTTPS_CLIENT_AUTH "
+fi
+
+if [ -n "$HTTPS_PROXY_NAME" ]; then
+  HTTPS_PROXY_NAME_PARAM="--stringparam https.proxyName $HTTPS_PROXY_NAME "
+fi
+
+if [ -n "$HTTPS_PROXY_PORT" ]; then
+  HTTPS_PROXY_PORT_PARAM="--stringparam https.proxyPort $HTTPS_PROXY_PORT "
+fi
+
+if [ -n "$HTTPS_COMPRESSION" ]; then
+  HTTPS_COMPRESSION_PARAM="--stringparam https.compression $HTTPS_COMPRESSION "
+fi
+
+if [ -n "$HTTPS_MAX_HEADER_SIZE" ]; then
+  HTTPS_MAX_HEADER_SIZE_PARAM="--stringparam https.maxHttpHeaderSize $HTTPS_MAX_HEADER_SIZE "
+fi
+
+if [ -n "$JKS_FILE" ]; then
+  JKS_FILE_PARAM="--stringparam https.keystoreFile ${CERT_DIR}/$JKS_FILE "
+fi
+if [ -n "$JKS_KEY_PASSWORD" ]; then
+  JKS_KEY_PASSWORD_PARAM="--stringparam https.keystorePass $JKS_KEY_PASSWORD "
+fi
+
+if [ -n "$KEY_ALIAS" ]; then
+  KEY_ALIAS_PARAM="--stringparam https.keyAlias $KEY_ALIAS "
+fi
+
+if [ -n "$JKS_STORE_PASSWORD" ]; then
+  JKS_STORE_PASSWORD_PARAM="--stringparam https.keyPass $JKS_STORE_PASSWORD "
+fi
+
+# Parse XML using xsltproc to insert variables into server.xml
+transform="xsltproc \
+  --output ${CATALINA_HOME}/conf/server.xml \
+  $HTTP_PORT_PARAM \
+  $HTTP_PROXY_NAME_PARAM \
+  $HTTP_PROXY_PORT_PARAM \
+  $HTTP_REDIRECT_PORT_PARAM \
+  $HTTP_CONNECTION_TIMEOUT_PARAM \
+  $HTTP_COMPRESSION_PARAM \
+  $HTTP_MAX_HEADER_SIZE_PARAM \
+  $HTTPS_PORT_PARAM \
+  $HTTPS_MAX_THREADS_PARAM \
+  $HTTPS_CLIENT_AUTH_PARAM \
+  $HTTPS_PROXY_NAME_PARAM \
+  $HTTPS_PROXY_PORT_PARAM \
+  $HTTPS_COMPRESSION_PARAM \
+  $HTTPS_MAX_HEADER_SIZE_PARAM \
+  $JKS_FILE_PARAM \
+  $JKS_KEY_PASSWORD_PARAM \
+  $KEY_ALIAS_PARAM \
+  $JKS_STORE_PASSWORD_PARAM \
+  ${CATALINA_HOME}/conf/tomcat_server_stylesheet.xsl \
+  ${CATALINA_HOME}/conf/server.xml"
+
+eval "$transform"

--- a/build/run.bat
+++ b/build/run.bat
@@ -1,0 +1,3 @@
+SET GS_PORT=8080
+
+docker run --name=geoserver_%GS_PORT% -p %GS_PORT%:8080 -d -v %HOME%/geoserver_data:/opt/geoserver/data_dir -e "HTTP_MAX_HEADER_SIZE=524288" -t thinkwhere/geoserver:2.18.3 /bin/sh -c conf/update_tomcat_settings.sh

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,3 +1,3 @@
 GS_PORT=8080
 
-docker run --name=geoserver_${GS_PORT} -p ${GS_PORT}:8080 -d -v $HOME/geoserver_data:/opt/geoserver/data_dir -t thinkwhere/geoserver:2.18.0
+docker run --name=geoserver_${GS_PORT} -p ${GS_PORT}:8080 -d -v $HOME/geoserver_data:/opt/geoserver/data_dir -t thinkwhere/geoserver:2.18.3

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,3 +1,3 @@
 GS_PORT=8080
 
-docker run --name=geoserver_${GS_PORT} -p ${GS_PORT}:8080 -d -v $HOME/geoserver_data:/opt/geoserver/data_dir -t thinkwhere/geoserver:2.18.3
+docker run --name=geoserver_${GS_PORT} -p ${GS_PORT}:8080 -d -v $HOME/geoserver_data:/opt/geoserver/data_dir -e "HTTP_MAX_HEADER_SIZE=524288" -t thinkwhere/geoserver:2.18.3 /bin/sh -c conf/update_tomcat_settings.sh


### PR DESCRIPTION
-  Solution by https://github.com/kartoza/docker-geoserver
- Add script which parses env variables and inserts them into `server.xml` using `xsltproc`
- Links to change on tmc-devops here - https://github.com/thinkWhere/themapcloud-devops/pull/426