### PR TITLE
Fix handling of community plugins in bash version of build script.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -30,9 +30,9 @@ done
 community_plugins=(s3-geotiff )
 for c in "${community_plugins[@]}"
 do
-	if [ ! -f resources/plugins/geoserver-${p}-plugin.zip ]
+	if [ ! -f resources/plugins/geoserver-${c}-plugin.zip ]
 	then
-		wget -c https://build.geoserver.org/geoserver/${BUILD_GS_VERSION}.x/community-latest/geoserver-${BUILD_GS_VERSION}-SNAPSHOT-${c}-plugin.zip -O resources/plugins/geoserver-${p}-plugin.zip
+		wget -c https://build.geoserver.org/geoserver/${BUILD_GS_VERSION}.x/community-latest/geoserver-${BUILD_GS_VERSION}-SNAPSHOT-${c}-plugin.zip -O resources/plugins/geoserver-${c}-plugin.zip
 	fi
 done
 


### PR DESCRIPTION
The bash version of the build script failed to include any community plugins.  Fix loop variable references in the loop that copies these plugins into the build area.